### PR TITLE
fix: use legacy bitnami repositories

### DIFF
--- a/charts/wallabag/Chart.lock
+++ b/charts/wallabag/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 2.31.0
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.31.4
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.9.13
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 17.17.1
-digest: sha256:9c4b8fc0d5bc91d6caf707cddc5f6d450a37c57862b00201452c778c571be26d
-generated: "2025-05-05T10:57:52.12704732Z"
+digest: sha256:4235055450231ef748192cc32775c782569ea0690f84ffd1bae70d682ea73829
+generated: "2025-10-04T08:25:03.949109795-07:00"

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -42,12 +42,12 @@ appVersion: 2.6.13
 dependencies:
   - name: common
     version: ~2.31.0
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
   - name: postgresql
     version: ~11.9.0
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: redis
     version: ~17.17.0
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/wallabag/values.yaml
+++ b/charts/wallabag/values.yaml
@@ -47,9 +47,13 @@ wallabag:
 postgresql:
   # -- Enable installation of postgresql subchart. See [bitnami/postgresql](https://github.com/bitnami/charts/tree/main/bitnami/postgresql/)
   enabled: false
+  image:
+    repository: bitnamilegacy/postgresql
 
 redis:
   enabled: false
+  image:
+    repository: bitnamilegacy/redis
   replica:
     replicaCount: 0
 


### PR DESCRIPTION
Bitnami has deprecated their helm and container image repositories https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon